### PR TITLE
Improve pattern READMEs, add catalog descriptions and demo runner in Program.cs

### DIFF
--- a/DesignPatternsInCSharp/Behavioral/ChainOfResponsibility/README.md
+++ b/DesignPatternsInCSharp/Behavioral/ChainOfResponsibility/README.md
@@ -4,14 +4,14 @@
 Pass a request through a chain of handlers.
 
 ## When to use
-- You need clear separation of concerns.
-- You want easier unit testing through abstractions.
-- You expect this behavior to evolve independently.
+- A request may be handled by one of many processors.
+- You need configurable processing pipelines.
+- Handlers should be reusable and independently testable.
 
 ## Example (C#)
 See `Example.cs` in this folder for a runnable, minimal implementation.
 
 ## Real-world use cases
-- Enterprise application modules.
-- API orchestration and workflows.
-- Domain services with evolving requirements.
+- HTTP middleware pipelines.
+- Validation chains on commands.
+- Support ticket escalation paths.

--- a/DesignPatternsInCSharp/Behavioral/Command/README.md
+++ b/DesignPatternsInCSharp/Behavioral/Command/README.md
@@ -4,14 +4,14 @@
 Encapsulate a request as an object for queueing, logging, and undo.
 
 ## When to use
-- You need clear separation of concerns.
-- You want easier unit testing through abstractions.
-- You expect this behavior to evolve independently.
+- You need to decouple UI actions from business execution logic.
+- You want to queue, schedule, or replay operations later.
+- You need undo/redo support by storing inverse commands.
 
 ## Example (C#)
 See `Example.cs` in this folder for a runnable, minimal implementation.
 
 ## Real-world use cases
-- Enterprise application modules.
-- API orchestration and workflows.
-- Domain services with evolving requirements.
+- Toolbar/menu actions in desktop apps.
+- Job queues for background processing.
+- Audit trails of user actions.

--- a/DesignPatternsInCSharp/Behavioral/DataAccess/README.md
+++ b/DesignPatternsInCSharp/Behavioral/DataAccess/README.md
@@ -4,14 +4,14 @@
 Abstract persistence concerns behind repositories/UoW.
 
 ## When to use
-- You need clear separation of concerns.
-- You want easier unit testing through abstractions.
-- You expect this behavior to evolve independently.
+- Domain logic should not depend on SQL/ORM details.
+- You want a seam for tests with in-memory fakes.
+- Multiple persistence implementations may be swapped later.
 
 ## Example (C#)
 See `Example.cs` in this folder for a runnable, minimal implementation.
 
 ## Real-world use cases
-- Enterprise application modules.
-- API orchestration and workflows.
-- Domain services with evolving requirements.
+- Repository per aggregate root.
+- Unit of Work transactions for multiple writes.
+- CQRS query/read model separation.

--- a/DesignPatternsInCSharp/Behavioral/Mediator/README.md
+++ b/DesignPatternsInCSharp/Behavioral/Mediator/README.md
@@ -4,14 +4,14 @@
 Coordinate object communication through a mediator.
 
 ## When to use
-- You need clear separation of concerns.
-- You want easier unit testing through abstractions.
-- You expect this behavior to evolve independently.
+- Many components interact and dependencies become tangled.
+- You need centralized orchestration for events/messages.
+- You want colleagues to depend on a hub instead of each other.
 
 ## Example (C#)
 See `Example.cs` in this folder for a runnable, minimal implementation.
 
 ## Real-world use cases
-- Enterprise application modules.
-- API orchestration and workflows.
-- Domain services with evolving requirements.
+- Chat room message routing.
+- UI form component coordination.
+- Workflow orchestration among services.

--- a/DesignPatternsInCSharp/Behavioral/Memento/README.md
+++ b/DesignPatternsInCSharp/Behavioral/Memento/README.md
@@ -4,14 +4,14 @@
 Capture and restore object state safely.
 
 ## When to use
-- You need clear separation of concerns.
-- You want easier unit testing through abstractions.
-- You expect this behavior to evolve independently.
+- You need undo/checkpoint behavior without exposing internals.
+- State snapshots should be stored and restored later.
+- You want immutable history records.
 
 ## Example (C#)
 See `Example.cs` in this folder for a runnable, minimal implementation.
 
 ## Real-world use cases
-- Enterprise application modules.
-- API orchestration and workflows.
-- Domain services with evolving requirements.
+- Text editor undo stacks.
+- Game save checkpoints.
+- Configuration rollback in admin tools.

--- a/DesignPatternsInCSharp/Behavioral/NullObject/README.md
+++ b/DesignPatternsInCSharp/Behavioral/NullObject/README.md
@@ -4,14 +4,14 @@
 Use a neutral object to avoid repeated null checks.
 
 ## When to use
-- You need clear separation of concerns.
-- You want easier unit testing through abstractions.
-- You expect this behavior to evolve independently.
+- A dependency can be optional but call sites should remain simple.
+- You want deterministic default behavior instead of `null` handling everywhere.
+- You want to apply polymorphism even when no-op behavior is needed.
 
 ## Example (C#)
 See `Example.cs` in this folder for a runnable, minimal implementation.
 
 ## Real-world use cases
-- Enterprise application modules.
-- API orchestration and workflows.
-- Domain services with evolving requirements.
+- Guest user profile in authentication flows.
+- No-op logger in tests or local runs.
+- Fallback notification sender.

--- a/DesignPatternsInCSharp/Behavioral/RulesEngine/README.md
+++ b/DesignPatternsInCSharp/Behavioral/RulesEngine/README.md
@@ -4,14 +4,14 @@
 Externalize decision logic as composable rules.
 
 ## When to use
-- You need clear separation of concerns.
-- You want easier unit testing through abstractions.
-- You expect this behavior to evolve independently.
+- Business decisions change often and should be configured.
+- You need traceable rule evaluation outcomes.
+- Multiple rule sets must be applied to different tenants/contexts.
 
 ## Example (C#)
 See `Example.cs` in this folder for a runnable, minimal implementation.
 
 ## Real-world use cases
-- Enterprise application modules.
-- API orchestration and workflows.
-- Domain services with evolving requirements.
+- Promotion eligibility engines.
+- Fraud detection pre-checks.
+- Policy-based access decisions.

--- a/DesignPatternsInCSharp/Behavioral/Specification/README.md
+++ b/DesignPatternsInCSharp/Behavioral/Specification/README.md
@@ -4,14 +4,14 @@
 Compose business rules into reusable predicates.
 
 ## When to use
-- You need clear separation of concerns.
-- You want easier unit testing through abstractions.
-- You expect this behavior to evolve independently.
+- Rules must be combined with AND/OR/NOT without duplicating code.
+- You need to reuse the same rule in memory and repository queries.
+- Business criteria evolve frequently and need testable units.
 
 ## Example (C#)
 See `Example.cs` in this folder for a runnable, minimal implementation.
 
 ## Real-world use cases
-- Enterprise application modules.
-- API orchestration and workflows.
-- Domain services with evolving requirements.
+- Product filtering in e-commerce search.
+- Eligibility rules in lending/insurance.
+- Compliance checks in onboarding workflows.

--- a/DesignPatternsInCSharp/Behavioral/State/README.md
+++ b/DesignPatternsInCSharp/Behavioral/State/README.md
@@ -4,14 +4,14 @@
 Change behavior when internal state changes.
 
 ## When to use
-- You need clear separation of concerns.
-- You want easier unit testing through abstractions.
-- You expect this behavior to evolve independently.
+- Object behavior depends heavily on lifecycle state.
+- You want to avoid giant conditionals that check state repeatedly.
+- Transitions between states must be explicit and controlled.
 
 ## Example (C#)
 See `Example.cs` in this folder for a runnable, minimal implementation.
 
 ## Real-world use cases
-- Enterprise application modules.
-- API orchestration and workflows.
-- Domain services with evolving requirements.
+- Order processing lifecycle.
+- Document workflow (draft/review/published).
+- Connection state in networking clients.

--- a/DesignPatternsInCSharp/Behavioral/Strategy/README.md
+++ b/DesignPatternsInCSharp/Behavioral/Strategy/README.md
@@ -4,14 +4,14 @@
 Select one of many interchangeable algorithms at runtime.
 
 ## When to use
-- You need clear separation of concerns.
-- You want easier unit testing through abstractions.
-- You expect this behavior to evolve independently.
+- You have multiple pricing, sorting, or validation algorithms that can be swapped by configuration or user type.
+- You want to remove long `if/else` or `switch` blocks that branch on behavior.
+- You need to add new algorithms without changing the caller class.
 
 ## Example (C#)
 See `Example.cs` in this folder for a runnable, minimal implementation.
 
 ## Real-world use cases
-- Enterprise application modules.
-- API orchestration and workflows.
-- Domain services with evolving requirements.
+- Payment pricing and discount policies.
+- Shipping rate calculators per region/carrier.
+- Retry policies for API clients.

--- a/DesignPatternsInCSharp/Behavioral/TemplateMethod/README.md
+++ b/DesignPatternsInCSharp/Behavioral/TemplateMethod/README.md
@@ -4,14 +4,14 @@
 Define algorithm skeleton and override specific steps.
 
 ## When to use
-- You need clear separation of concerns.
-- You want easier unit testing through abstractions.
-- You expect this behavior to evolve independently.
+- Process steps are stable but some steps vary by subtype.
+- You want a common flow while preventing step reordering.
+- You need to reuse invariant setup/cleanup logic.
 
 ## Example (C#)
 See `Example.cs` in this folder for a runnable, minimal implementation.
 
 ## Real-world use cases
-- Enterprise application modules.
-- API orchestration and workflows.
-- Domain services with evolving requirements.
+- File importers for CSV/JSON/XML.
+- Batch processing job templates.
+- Test fixture setup pipelines.

--- a/DesignPatternsInCSharp/Behavioral/Visitor/README.md
+++ b/DesignPatternsInCSharp/Behavioral/Visitor/README.md
@@ -4,14 +4,14 @@
 Add new operations over object structures without changing classes.
 
 ## When to use
-- You need clear separation of concerns.
-- You want easier unit testing through abstractions.
-- You expect this behavior to evolve independently.
+- Object structure is stable but operations change frequently.
+- You need type-safe double dispatch across element variants.
+- You want to keep operations separate from data structures.
 
 ## Example (C#)
 See `Example.cs` in this folder for a runnable, minimal implementation.
 
 ## Real-world use cases
-- Enterprise application modules.
-- API orchestration and workflows.
-- Domain services with evolving requirements.
+- AST analysis and code generation.
+- Report/export generation over domain graphs.
+- Pricing engines over product hierarchies.

--- a/DesignPatternsInCSharp/Creational/AbstractFactory/README.md
+++ b/DesignPatternsInCSharp/Creational/AbstractFactory/README.md
@@ -4,14 +4,14 @@
 Create related object families without concrete coupling.
 
 ## When to use
-- You need clear separation of concerns.
-- You want easier unit testing through abstractions.
-- You expect this behavior to evolve independently.
+- Multiple related products must be created together consistently.
+- You need to switch whole families (e.g., themes/providers).
+- Client code should remain independent of concrete implementations.
 
 ## Example (C#)
 See `Example.cs` in this folder for a runnable, minimal implementation.
 
 ## Real-world use cases
-- Enterprise application modules.
-- API orchestration and workflows.
-- Domain services with evolving requirements.
+- Cross-platform UI widget families.
+- Database providers with matching commands/connections.
+- Cloud provider specific SDK wrappers.

--- a/DesignPatternsInCSharp/Creational/Builder/README.md
+++ b/DesignPatternsInCSharp/Creational/Builder/README.md
@@ -4,14 +4,14 @@
 Build complex objects step-by-step.
 
 ## When to use
-- You need clear separation of concerns.
-- You want easier unit testing through abstractions.
-- You expect this behavior to evolve independently.
+- Objects require many optional parameters or construction steps.
+- You want readable construction with validation before `Build()`.
+- Construction logic should be separated from representation.
 
 ## Example (C#)
 See `Example.cs` in this folder for a runnable, minimal implementation.
 
 ## Real-world use cases
-- Enterprise application modules.
-- API orchestration and workflows.
-- Domain services with evolving requirements.
+- Creating HTTP requests with optional headers/body.
+- Building complex domain aggregates.
+- Generating reports with configurable sections.

--- a/DesignPatternsInCSharp/Creational/FactoryMethod/README.md
+++ b/DesignPatternsInCSharp/Creational/FactoryMethod/README.md
@@ -4,14 +4,14 @@
 Delegate object creation to subclasses/factories.
 
 ## When to use
-- You need clear separation of concerns.
-- You want easier unit testing through abstractions.
-- You expect this behavior to evolve independently.
+- Client code should depend on abstractions, not concrete constructors.
+- Object creation varies by environment, channel, or tenant.
+- You want to centralize creation and enforce invariants.
 
 ## Example (C#)
 See `Example.cs` in this folder for a runnable, minimal implementation.
 
 ## Real-world use cases
-- Enterprise application modules.
-- API orchestration and workflows.
-- Domain services with evolving requirements.
+- Notification channel factories.
+- Storage provider factories.
+- Serializer selection based on content type.

--- a/DesignPatternsInCSharp/Creational/Prototype/README.md
+++ b/DesignPatternsInCSharp/Creational/Prototype/README.md
@@ -4,14 +4,14 @@
 Clone existing instances efficiently.
 
 ## When to use
-- You need clear separation of concerns.
-- You want easier unit testing through abstractions.
-- You expect this behavior to evolve independently.
+- Creating objects from scratch is expensive.
+- You need many similar objects with small variations.
+- You want to hide concrete class construction from clients.
 
 ## Example (C#)
 See `Example.cs` in this folder for a runnable, minimal implementation.
 
 ## Real-world use cases
-- Enterprise application modules.
-- API orchestration and workflows.
-- Domain services with evolving requirements.
+- Copying document templates.
+- Spawning game entities from base stats.
+- Cloning workflow definitions.

--- a/DesignPatternsInCSharp/Creational/Singleton/README.md
+++ b/DesignPatternsInCSharp/Creational/Singleton/README.md
@@ -4,14 +4,14 @@
 Guarantee one instance with global access point.
 
 ## When to use
-- You need clear separation of concerns.
-- You want easier unit testing through abstractions.
-- You expect this behavior to evolve independently.
+- There must be exactly one shared instance (e.g., process-wide config).
+- You need lazy or centralized access with controlled construction.
+- You can tolerate global state trade-offs and test constraints.
 
 ## Example (C#)
 See `Example.cs` in this folder for a runnable, minimal implementation.
 
 ## Real-world use cases
-- Enterprise application modules.
-- API orchestration and workflows.
-- Domain services with evolving requirements.
+- Application configuration registry.
+- In-process cache coordinator.
+- Feature flag provider bootstrap.

--- a/DesignPatternsInCSharp/Structural/Adapter/README.md
+++ b/DesignPatternsInCSharp/Structural/Adapter/README.md
@@ -4,14 +4,14 @@
 Convert one interface to another expected by clients.
 
 ## When to use
-- You need clear separation of concerns.
-- You want easier unit testing through abstractions.
-- You expect this behavior to evolve independently.
+- You must integrate legacy/third-party APIs with incompatible interfaces.
+- You want to keep client code unchanged while swapping providers.
+- You need a translation layer for request/response models.
 
 ## Example (C#)
 See `Example.cs` in this folder for a runnable, minimal implementation.
 
 ## Real-world use cases
-- Enterprise application modules.
-- API orchestration and workflows.
-- Domain services with evolving requirements.
+- Wrapping external payment SDKs.
+- Legacy logging API migration.
+- Bridging old/new service contracts.

--- a/DesignPatternsInCSharp/Structural/Bridge/README.md
+++ b/DesignPatternsInCSharp/Structural/Bridge/README.md
@@ -1,17 +1,17 @@
 # Bridge Pattern
 
 ## Intent
-Separate abstraction from implementation.
+Decouple abstraction from implementation so both can vary.
 
 ## When to use
-- You need clear separation of concerns.
-- You want easier unit testing through abstractions.
-- You expect this behavior to evolve independently.
+- Both abstraction and implementation axes evolve independently.
+- You want to avoid combinatorial subclass growth.
+- Implementation should be swappable at runtime.
 
 ## Example (C#)
 See `Example.cs` in this folder for a runnable, minimal implementation.
 
 ## Real-world use cases
-- Enterprise application modules.
-- API orchestration and workflows.
-- Domain services with evolving requirements.
+- Notification types × delivery channels.
+- Remote controls × device types.
+- Document types × rendering backends.

--- a/DesignPatternsInCSharp/Structural/Composite/README.md
+++ b/DesignPatternsInCSharp/Structural/Composite/README.md
@@ -1,17 +1,17 @@
 # Composite Pattern
 
 ## Intent
-Treat leaves and groups uniformly.
+Treat part-whole hierarchies uniformly.
 
 ## When to use
-- You need clear separation of concerns.
-- You want easier unit testing through abstractions.
-- You expect this behavior to evolve independently.
+- You work with tree structures containing leaves and groups.
+- Clients should perform operations on single and grouped objects uniformly.
+- You need recursive traversal and aggregation behavior.
 
 ## Example (C#)
 See `Example.cs` in this folder for a runnable, minimal implementation.
 
 ## Real-world use cases
-- Enterprise application modules.
-- API orchestration and workflows.
-- Domain services with evolving requirements.
+- File system directories/files.
+- Organization charts.
+- UI component trees.

--- a/DesignPatternsInCSharp/Structural/Decorator/README.md
+++ b/DesignPatternsInCSharp/Structural/Decorator/README.md
@@ -1,17 +1,17 @@
 # Decorator Pattern
 
 ## Intent
-Attach responsibilities dynamically at runtime.
+Attach responsibilities to objects dynamically.
 
 ## When to use
-- You need clear separation of concerns.
-- You want easier unit testing through abstractions.
-- You expect this behavior to evolve independently.
+- You need optional features layered at runtime.
+- Subclass explosion would occur for all feature combinations.
+- You want to follow open/closed principle for behavior extension.
 
 ## Example (C#)
 See `Example.cs` in this folder for a runnable, minimal implementation.
 
 ## Real-world use cases
-- Enterprise application modules.
-- API orchestration and workflows.
-- Domain services with evolving requirements.
+- Middleware-style request processing.
+- Adding caching/retry/logging around services.
+- UI component enhancement (borders, scrollbars).

--- a/DesignPatternsInCSharp/Structural/Facade/README.md
+++ b/DesignPatternsInCSharp/Structural/Facade/README.md
@@ -1,17 +1,17 @@
 # Facade Pattern
 
 ## Intent
-Expose a simple API over complex subsystems.
+Provide a simplified API over a complex subsystem.
 
 ## When to use
-- You need clear separation of concerns.
-- You want easier unit testing through abstractions.
-- You expect this behavior to evolve independently.
+- A subsystem is complex and clients need a simpler entry point.
+- You want to reduce coupling to many low-level types.
+- You need a stable API while subsystem internals evolve.
 
 ## Example (C#)
 See `Example.cs` in this folder for a runnable, minimal implementation.
 
 ## Real-world use cases
-- Enterprise application modules.
-- API orchestration and workflows.
-- Domain services with evolving requirements.
+- Checkout orchestration over payment/inventory/shipping.
+- Media pipeline wrapper services.
+- Third-party SDK simplification layer.

--- a/DesignPatternsInCSharp/Structural/Flyweight/README.md
+++ b/DesignPatternsInCSharp/Structural/Flyweight/README.md
@@ -1,17 +1,17 @@
 # Flyweight Pattern
 
 ## Intent
-Share intrinsic state to reduce memory usage.
+Share intrinsic state to support many fine-grained objects.
 
 ## When to use
-- You need clear separation of concerns.
-- You want easier unit testing through abstractions.
-- You expect this behavior to evolve independently.
+- You have huge numbers of similar objects causing memory pressure.
+- Large immutable state can be shared across instances.
+- Extrinsic state can be supplied from context at runtime.
 
 ## Example (C#)
 See `Example.cs` in this folder for a runnable, minimal implementation.
 
 ## Real-world use cases
-- Enterprise application modules.
-- API orchestration and workflows.
-- Domain services with evolving requirements.
+- Text editor glyph caching.
+- Map marker/icon reuse.
+- Game particle type sharing.

--- a/DesignPatternsInCSharp/Structural/Proxy/README.md
+++ b/DesignPatternsInCSharp/Structural/Proxy/README.md
@@ -1,17 +1,17 @@
 # Proxy Pattern
 
 ## Intent
-Control access to another object.
+Control access to an object via a surrogate.
 
 ## When to use
-- You need clear separation of concerns.
-- You want easier unit testing through abstractions.
-- You expect this behavior to evolve independently.
+- You need lazy initialization, caching, security, or remote access concerns.
+- Client should interact through same interface as real service.
+- You want to wrap expensive dependencies transparently.
 
 ## Example (C#)
 See `Example.cs` in this folder for a runnable, minimal implementation.
 
 ## Real-world use cases
-- Enterprise application modules.
-- API orchestration and workflows.
-- Domain services with evolving requirements.
+- Virtual proxy for heavy images/documents.
+- API client with access token checks.
+- Caching proxy for read-heavy queries.

--- a/DesignPatternsInCSharp/docs/PATTERNS.md
+++ b/DesignPatternsInCSharp/docs/PATTERNS.md
@@ -1,32 +1,32 @@
 # Pattern Catalog
-This catalog links every implemented pattern example in this repository.
+This catalog links every implemented pattern example in this repository and explains when each is typically used.
 
 ## Behavioral
-- [Strategy](../Behavioral/Strategy/README.md)
-- [Command](../Behavioral/Command/README.md)
-- [NullObject](../Behavioral/NullObject/README.md)
-- [Specification](../Behavioral/Specification/README.md)
-- [State](../Behavioral/State/README.md)
-- [DataAccess](../Behavioral/DataAccess/README.md)
-- [Mediator](../Behavioral/Mediator/README.md)
-- [ChainOfResponsibility](../Behavioral/ChainOfResponsibility/README.md)
-- [TemplateMethod](../Behavioral/TemplateMethod/README.md)
-- [Visitor](../Behavioral/Visitor/README.md)
-- [Memento](../Behavioral/Memento/README.md)
-- [RulesEngine](../Behavioral/RulesEngine/README.md)
+- [Strategy](../Behavioral/Strategy/README.md): Swap algorithms (pricing/validation) at runtime.
+- [Command](../Behavioral/Command/README.md): Wrap requests as objects for queueing/undo.
+- [NullObject](../Behavioral/NullObject/README.md): Replace `null` checks with no-op polymorphism.
+- [Specification](../Behavioral/Specification/README.md): Compose reusable business rules.
+- [State](../Behavioral/State/README.md): Change behavior by lifecycle state.
+- [DataAccess](../Behavioral/DataAccess/README.md): Isolate persistence behind abstractions.
+- [Mediator](../Behavioral/Mediator/README.md): Centralize communication between components.
+- [ChainOfResponsibility](../Behavioral/ChainOfResponsibility/README.md): Pass requests through processing pipeline.
+- [TemplateMethod](../Behavioral/TemplateMethod/README.md): Fix algorithm skeleton, vary individual steps.
+- [Visitor](../Behavioral/Visitor/README.md): Add operations over object structures safely.
+- [Memento](../Behavioral/Memento/README.md): Capture and restore previous state.
+- [RulesEngine](../Behavioral/RulesEngine/README.md): Externalize decision logic as rules.
 
 ## Creational
-- [Singleton](../Creational/Singleton/README.md)
-- [Builder](../Creational/Builder/README.md)
-- [Prototype](../Creational/Prototype/README.md)
-- [FactoryMethod](../Creational/FactoryMethod/README.md)
-- [AbstractFactory](../Creational/AbstractFactory/README.md)
+- [Singleton](../Creational/Singleton/README.md): Ensure a single shared instance.
+- [Builder](../Creational/Builder/README.md): Build complex objects step-by-step.
+- [Prototype](../Creational/Prototype/README.md): Clone existing objects efficiently.
+- [FactoryMethod](../Creational/FactoryMethod/README.md): Delegate construction to factories.
+- [AbstractFactory](../Creational/AbstractFactory/README.md): Create related families of objects.
 
 ## Structural
-- [Facade](../Structural/Facade/README.md)
-- [Decorator](../Structural/Decorator/README.md)
-- [Composite](../Structural/Composite/README.md)
-- [Adapter](../Structural/Adapter/README.md)
-- [Flyweight](../Structural/Flyweight/README.md)
-- [Proxy](../Structural/Proxy/README.md)
-- [Bridge](../Structural/Bridge/README.md)
+- [Facade](../Structural/Facade/README.md): Provide a simpler API over complex systems.
+- [Decorator](../Structural/Decorator/README.md): Layer optional behaviors dynamically.
+- [Composite](../Structural/Composite/README.md): Treat groups and single objects uniformly.
+- [Adapter](../Structural/Adapter/README.md): Translate between incompatible interfaces.
+- [Flyweight](../Structural/Flyweight/README.md): Share intrinsic state to reduce memory.
+- [Proxy](../Structural/Proxy/README.md): Control access via a stand-in object.
+- [Bridge](../Structural/Bridge/README.md): Decouple abstraction and implementation axes.

--- a/DesignPatternsInCSharp/src/Program.cs
+++ b/DesignPatternsInCSharp/src/Program.cs
@@ -1,4 +1,49 @@
 using System;
-using DesignPatternsInCSharp.Behavioral.Strategy;
+using System.Collections.Generic;
 
-Console.WriteLine($"Strategy sample total: {Example.Run()}");
+var demos = new List<(string Category, string Pattern, Func<string> Run)>
+{
+    // Behavioral
+    ("Behavioral", "Strategy", () => DesignPatternsInCSharp.Behavioral.Strategy.Example.Run().ToString("0.00")),
+    ("Behavioral", "Command", () => DesignPatternsInCSharp.Behavioral.Command.Example.Run().ToString()),
+    ("Behavioral", "NullObject", () => DesignPatternsInCSharp.Behavioral.NullObject.Example.Run()),
+    ("Behavioral", "Specification", () => DesignPatternsInCSharp.Behavioral.Specification.Example.Run()),
+    ("Behavioral", "State", () => DesignPatternsInCSharp.Behavioral.State.Example.Run()),
+    ("Behavioral", "DataAccess", () => DesignPatternsInCSharp.Behavioral.DataAccess.Example.Run()),
+    ("Behavioral", "Mediator", () => DesignPatternsInCSharp.Behavioral.Mediator.Example.Run()),
+    ("Behavioral", "ChainOfResponsibility", () => DesignPatternsInCSharp.Behavioral.ChainOfResponsibility.Example.Run()),
+    ("Behavioral", "TemplateMethod", () => DesignPatternsInCSharp.Behavioral.TemplateMethod.Example.Run()),
+    ("Behavioral", "Visitor", () => DesignPatternsInCSharp.Behavioral.Visitor.Example.Run()),
+    ("Behavioral", "Memento", () => DesignPatternsInCSharp.Behavioral.Memento.Example.Run()),
+    ("Behavioral", "RulesEngine", () => DesignPatternsInCSharp.Behavioral.RulesEngine.Example.Run()),
+
+    // Creational
+    ("Creational", "Singleton", () => DesignPatternsInCSharp.Creational.Singleton.Example.Run()),
+    ("Creational", "Builder", () => DesignPatternsInCSharp.Creational.Builder.Example.Run()),
+    ("Creational", "Prototype", () => DesignPatternsInCSharp.Creational.Prototype.Example.Run()),
+    ("Creational", "FactoryMethod", () => DesignPatternsInCSharp.Creational.FactoryMethod.Example.Run()),
+    ("Creational", "AbstractFactory", () => DesignPatternsInCSharp.Creational.AbstractFactory.Example.Run()),
+
+    // Structural
+    ("Structural", "Facade", () => DesignPatternsInCSharp.Structural.Facade.Example.Run()),
+    ("Structural", "Decorator", () => DesignPatternsInCSharp.Structural.Decorator.Example.Run()),
+    ("Structural", "Composite", () => DesignPatternsInCSharp.Structural.Composite.Example.Run()),
+    ("Structural", "Adapter", () => DesignPatternsInCSharp.Structural.Adapter.Example.Run()),
+    ("Structural", "Flyweight", () => DesignPatternsInCSharp.Structural.Flyweight.Example.Run()),
+    ("Structural", "Proxy", () => DesignPatternsInCSharp.Structural.Proxy.Example.Run()),
+    ("Structural", "Bridge", () => DesignPatternsInCSharp.Structural.Bridge.Example.Run())
+};
+
+Console.WriteLine("Design Patterns Demo Runner\n");
+
+string currentCategory = string.Empty;
+foreach (var (category, pattern, run) in demos)
+{
+    if (!string.Equals(currentCategory, category, StringComparison.Ordinal))
+    {
+        currentCategory = category;
+        Console.WriteLine($"[{currentCategory}]");
+    }
+
+    Console.WriteLine($"- {pattern}: {run()}");
+}

--- a/README.md
+++ b/README.md
@@ -32,9 +32,14 @@ Singleton, Builder, Prototype, Factory Method, Abstract Factory.
 Facade, Decorator, Composite, Adapter, Flyweight, Proxy, Bridge.
 
 ## Quick Start
-1. Open `DesignPatternsInCSharp/docs/PATTERNS.md`.
-2. Pick a pattern folder.
-3. Read pattern intent in `README.md` and inspect `Example.cs`.
+1. Open `DesignPatternsInCSharp/docs/PATTERNS.md` and pick a pattern.
+2. Read that folder's `README.md` for intent, usage guidance, and real-world examples.
+3. Inspect `Example.cs` for the runnable implementation.
+4. Run all pattern samples together:
+
+```bash
+dotnet run --project DesignPatternsInCSharp/src/DesignPatternsInCSharp.csproj
+```
 
 ## Contributing
 - Improve examples with richer domain scenarios.


### PR DESCRIPTION
### Motivation
- Make each pattern folder self-contained with clearer `Intent`, practical `When to use` guidance, and concrete real-world examples to aid learning and decision-making.
- Improve repository discoverability by adding one-line pattern descriptions to the catalog so readers can quickly find relevant patterns.
- Provide a single, runnable demo that exercises every example so contributors and learners can easily run and inspect outputs from all patterns.

### Description
- Rewrote `README.md` inside each pattern folder under `DesignPatternsInCSharp/Behavioral`, `DesignPatternsInCSharp/Creational`, and `DesignPatternsInCSharp/Structural` to include focused `Intent`, three concise `When to use` bullets, and three `Real-world use cases` bullets for each pattern.
- Enhanced `DesignPatternsInCSharp/docs/PATTERNS.md` to include a one-line description for every pattern link to speed navigation and context discovery.
- Replaced the single-sample entrypoint with a demo runner in `DesignPatternsInCSharp/src/Program.cs` that calls every pattern `Example.Run()` and prints grouped output by category.
- Updated the repository root `README.md` quick-start to point at the new catalog guidance and to show the command to run all patterns via `dotnet run`.

### Testing
- Attempted to execute the demo with `dotnet run --project DesignPatternsInCSharp/src/DesignPatternsInCSharp.csproj`, which failed in this environment because the `dotnet` SDK is not installed (`bash: command not found: dotnet`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bde99b9d483208a16b11b6ae30a01)